### PR TITLE
Support for `height` on Dimensions

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    publicstorage (1.0.0)
+    publicstorage (1.1.0)
       http
       json
       nokogiri

--- a/lib/publicstorage/dimensions.rb
+++ b/lib/publicstorage/dimensions.rb
@@ -1,8 +1,10 @@
 # frozen_string_literal: true
 
 module PublicStorage
-  # The dimensions (width + depth + sqft) of a price.
+  # The dimensions (width + depth + height) of a price.
   class Dimensions
+    DEFAULT_HEIGHT = 8.0 # feet
+
     SELECTOR = '.unit-size'
 
     # @attribute [rw] depth
@@ -13,17 +15,17 @@ module PublicStorage
     #  @return [Integer]
     attr_accessor :width
 
-    # @attribute [rw] sqft
-    #   @return [Integer]
-    attr_accessor :sqft
+    # @attribute [rw] height
+    #  @return [Integer]
+    attr_accessor :height
 
     # @param depth [Float]
     # @param width [Float]
-    # @param sqft [Integer]
-    def initialize(depth:, width:, sqft:)
+    # @param height [Float]
+    def initialize(depth:, width:, height: DEFAULT_HEIGHT)
       @depth = depth
       @width = width
-      @sqft = sqft
+      @height = height
     end
 
     # @return [String]
@@ -31,14 +33,24 @@ module PublicStorage
       props = [
         "depth=#{@depth.inspect}",
         "width=#{@width.inspect}",
-        "sqft=#{@sqft.inspect}"
+        "height=#{@height.inspect}"
       ]
       "#<#{self.class.name} #{props.join(' ')}>"
     end
 
     # @return [String] e.g. "10' × 10' (100 sqft)"
     def text
-      "#{format('%g', @width)}' × #{format('%g', @depth)}' (#{@sqft} sqft)"
+      "#{format('%g', @width)}' × #{format('%g', @depth)}' (#{sqft} sqft)"
+    end
+
+    # @return [Integer]
+    def sqft
+      Integer(@width * @depth)
+    end
+
+    # @return [Integer]
+    def cuft
+      Integer(@width * @depth * @height)
     end
 
     # @param data [Hash]
@@ -48,9 +60,8 @@ module PublicStorage
       match = data['dimension'].match(/(?<depth>[\d\.]+)'x(?<width>[\d\.]+)'/)
       depth = Float(match[:depth])
       width = Float(match[:width])
-      sqft = Integer(depth * width)
 
-      new(depth:, width:, sqft:)
+      new(depth:, width:, height: DEFAULT_HEIGHT)
     end
   end
 end

--- a/lib/publicstorage/version.rb
+++ b/lib/publicstorage/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module PublicStorage
-  VERSION = '1.0.0'
+  VERSION = '1.1.0'
 end


### PR DESCRIPTION
This supports using a height w/ any dimensions. For now it defaults to 8.0 (since PublicStorage doesn't list heights).