### PR TITLE
Support `url` + `email` + `phone` on Facilities

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -21,3 +21,6 @@ Layout/FirstHashElementIndentation:
 
 Layout/FirstArrayElementIndentation:
   EnforcedStyle: consistent
+
+Metrics/ParameterLists:
+  Enabled: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    publicstorage (1.1.0)
+    publicstorage (1.2.0)
       http
       json
       nokogiri

--- a/lib/publicstorage/facility.rb
+++ b/lib/publicstorage/facility.rb
@@ -5,6 +5,9 @@ module PublicStorage
   class Facility
     SITEMAP_URL = 'https://www.publicstorage.com/sitemap_0-product.xml'
 
+    DEFAULT_PHONE = '1-800-742-8048'
+    DEFAULT_EMAIL = 'customerservice@publicstorage.com'
+
     PRICE_SELECTOR = '.units-results-section .unit-list-group .unit-list-item'
     LD_SELECTOR = 'script[type="application/ld+json"]'
 
@@ -14,9 +17,21 @@ module PublicStorage
     #   @return [Integer]
     attr_accessor :id
 
+    # @attribute [rw] url
+    #   @return [String]
+    attr_accessor :url
+
     # @attribute [rw] name
     #   @return [String]
     attr_accessor :name
+
+    # @attribute [rw] phone
+    #   @return [String]
+    attr_accessor :phone
+
+    # @attribute [rw] email
+    #   @return [String]
+    attr_accessor :email
 
     # @attribute [rw] address
     #   @return [Address]
@@ -40,13 +55,13 @@ module PublicStorage
     # @return [Facility]
     def self.fetch(url:)
       document = Crawler.html(url:)
-      parse(document:)
+      parse(url:, document:)
     end
 
     # @param document [NokoGiri::XML::Document]
     #
     # @return [Facility]
-    def self.parse(document:)
+    def self.parse(url:, document:)
       data = parse_ld(document:)
       id = Integer(data['url'].match(ID_REGEX)[:id])
       name = data['name']
@@ -55,7 +70,7 @@ module PublicStorage
 
       prices = document.css(PRICE_SELECTOR).map { |element| Price.parse(element:) }
 
-      new(id:, name:, address:, geocode:, prices:)
+      new(id:, url:, name:, address:, geocode:, prices:)
     end
 
     # @param document [NokoGiri::XML::Document]
@@ -81,23 +96,31 @@ module PublicStorage
     end
 
     # @param id [String]
+    # @param url [String]
     # @param name [String]
     # @param address [Address]
     # @param geocode [Geocode]
     # @param prices [Array<Price>]
-    def initialize(id:, name:, address:, geocode:, prices:)
+    def initialize(id:, url:, name:, address:, geocode:, phone: DEFAULT_PHONE, email: DEFAULT_EMAIL, prices: [])
       @id = id
+      @url = url
       @name = name
       @address = address
       @geocode = geocode
+      @phone = phone
+      @email = email
       @prices = prices
     end
 
     # @return [String]
     def inspect
       props = [
+        "id=#{@id.inspect}",
+        "url=#{@url.inspect}",
         "address=#{@address.inspect}",
         "geocode=#{@geocode.inspect}",
+        "phone=#{@phone.inspect}",
+        "email=#{@email.inspect}",
         "prices=#{@prices.inspect}"
       ]
       "#<#{self.class.name} #{props.join(' ')}>"

--- a/lib/publicstorage/version.rb
+++ b/lib/publicstorage/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module PublicStorage
-  VERSION = '1.1.0'
+  VERSION = '1.2.0'
 end


### PR DESCRIPTION
Currently the `email` + `phone` are constants (in the future this can be swapped to more targeted values) and the `url` is via the fetch.