### PR TITLE
Parse a better name via DOM

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    publicstorage (1.3.0)
+    publicstorage (1.4.0)
       http
       json
       nokogiri

--- a/lib/publicstorage/address.rb
+++ b/lib/publicstorage/address.rb
@@ -51,11 +51,21 @@ module PublicStorage
     # @return [Address]
     def self.parse(data:)
       new(
-        street: data['streetAddress'],
+        street: stripe_leading_or_trailing_null(data['streetAddress']),
         city: data['addressLocality'],
         state: data['addressRegion'],
         zip: data['postalCode']
       )
+    end
+
+    # NOTE: this fixes a bug w/ publicstorage that currently exists where addresses have a leading / trailing null.
+    #
+    # @param value [String]
+    #
+    # @return [String]
+    def self.stripe_leading_or_trailing_null(value)
+      match = value.match(/\A(?:null)?(?<text>.*?)(?:null)?\z/)
+      match[:text]
     end
   end
 end

--- a/lib/publicstorage/version.rb
+++ b/lib/publicstorage/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module PublicStorage
-  VERSION = '1.3.0'
+  VERSION = '1.4.0'
 end


### PR DESCRIPTION
This parses a more complete name. Lastly it fixes a scraping bug w/ addresses. Without this change every facility had the name 'Public Storage'. With this change facilities have a name like 'Public Storage Self-Storage Units at 315 S 4th Ave, Venice, CA'